### PR TITLE
Request to Add The PEOPLE (Utility Token)

### DIFF
--- a/resources/tokens.json
+++ b/resources/tokens.json
@@ -92,5 +92,12 @@
         "symbol": "MAIL",
         "account": "mailcontract",
         "chain": "tlos"
+    },
+    {
+        "name": "PEOPLE (Utility Token)",
+        "logo": "https://raw.githubusercontent.com/telos-foundation/sqrl/master/resources/Images/PEOPLE_Token_256.png",
+        "symbol": "PEOPLE",
+        "account": "vapaeetokens",
+        "chain": "tlos"
     }
 ]


### PR DESCRIPTION
The PEOPLE (Utility Token) is a multi-purpose token. It has been issued for multiple purposes, including, but not limited to: Community Building, Influence the behaviour of The People’s Proxy "peoplesproxy" to align with token holder's interests (DAC), Software/Tools Licensing, and On-boarding of new users on Telos Blockchain. It is The People's every day utility token. It represents People's Voice, People's Sentiment and People's Empowerment.

https://vapaee.io/exchange/token/people